### PR TITLE
Add MacPorts Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@ Right now we only support automatic Linux installation, but the code should work
 wget -qO - https://raw.githubusercontent.com/goDoCer/scientiaCLI/main/linux-installer.sh | bash
 ```
 
-### Windows/MacOS
+### macOS
+
+scientiaCLI can be installed via [MacPorts](https://ports.macports.org/port/scientiaCLI/):
+
+```bash
+sudo port install scientiaCLI
+```
+
+### Windows
 
 Coming soon (Make an issue if you want this really quick)
 


### PR DESCRIPTION
Hi there 👋 I'm Haren, a first year Comp Sci student at Imperial. I really liked this project, so I thought I'd help by adding it to [MacPorts](https://www.macports.org/).

scientiaCLI can now be installed on macOS by running the following:

```shell
sudo port install scientiaCLI
```

Pre-built binaries are provided for the latest macOS 12 arm all the way down to 10.7. Shell completion is also provided for bash, zsh and fish. You can find the install script [here](https://github.com/macports/macports-ports/tree/master/science/scientiaCLI), and its MacPorts page [here](https://ports.macports.org/port/scientiaCLI/).

Finally, it goes without saying, but thank you for maintaining this really useful project. ⭐